### PR TITLE
Fix the link of the authenticator example

### DIFF
--- a/packages/amplify_authenticator/README.md
+++ b/packages/amplify_authenticator/README.md
@@ -4,7 +4,7 @@ The Amplify Flutter Authenticator simplifies the process of authenticating users
 
 ## Example
 
-See the [example](https://github.com/aws-amplify/amplify-flutter/tree/release-candidate/packages/amplify_authenticator/example) which showcases many of the customizations available.
+See the [example](https://github.com/aws-amplify/amplify-flutter/tree/main/packages/amplify_authenticator/example) which showcases many of the customizations available.
 
 ## Getting Started
 


### PR DESCRIPTION
The link for amplify_authenticator/example/ is broken 

![Screen Shot 2023-03-13 at 3 12 11 PM](https://user-images.githubusercontent.com/12375969/224844134-4c30f675-15dd-44c6-9de3-b71bb0e89e89.png)

Before 


![Screen Shot 2023-03-13 at 3 14 00 PM](https://user-images.githubusercontent.com/12375969/224844724-9a6cd70c-5fbd-46a4-862c-1c3dcf422c63.png)


After 


![Screen Shot 2023-03-13 at 3 14 49 PM](https://user-images.githubusercontent.com/12375969/224844754-a168e8bd-40dc-4dba-922d-a6125410cb98.png)

